### PR TITLE
Bump deps to remove "No ns form found" error in boot_reload.cljs

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,10 +1,9 @@
 (set-env!
   :dependencies '[[adzerk/boot-cljs          "1.7.228-1"]
-                  [adzerk/boot-reload        "0.4.7"]
-                  [hoplon/boot-hoplon        "0.1.13"]
-                  [hoplon/hoplon             "6.0.0-alpha14"]
-                  [org.clojure/clojure       "1.7.0"]
-                  [org.clojure/clojurescript "1.8.51"]
+                  [adzerk/boot-reload        "0.4.13"]
+                  [hoplon/hoplon             "7.0.1"]
+                  [org.clojure/clojure       "1.8.0"]
+                  [org.clojure/clojurescript "1.9.293"]
                   [tailrecursion/boot-jetty  "0.1.3"]]
   :source-paths #{"src"}
   :asset-paths  #{"assets"})


### PR DESCRIPTION
Removes error when running `boot dev`:

```
Compiling Hoplon pages...
• app/main.cljs.hl
Writing main.cljs.edn...
Compiling ClojureScript...
• main.js
java.lang.AssertionError: No ns form found in file:/path/to/.../embedded-hoplon-example/9ek/-grrwi1/adzerk/boot_reload.cljs
cljs.analyzer$parse_ns$fn__2110.invoke  analyzer.cljc: 2761
         cljs.analyzer$parse_ns.invoke  analyzer.cljc: 2711
         cljs.analyzer$parse_ns.invoke  analyzer.cljc: 2703
   cljs.closure/find-cljs-dependencies    closure.clj:  733
   cljs.closure/add-dependency-sources    closure.clj:  800
                    cljs.closure/build    closure.clj: 1941
                  cljs.build.api/build        api.clj:  210
    adzerk.boot-cljs.impl/compile-cljs       impl.clj:   89
                                   ...
                    clojure.core/apply       core.clj:  630
                 boot.pod/eval-fn-call        pod.clj:  294
                     boot.pod/call-in*        pod.clj:  315
                                   ...
                     boot.pod/call-in*        pod.clj:  318
              adzerk.boot-cljs/compile  boot_cljs.clj:   71
         adzerk.boot-cljs/compile-1/fn  boot_cljs.clj:  126
   clojure.core/binding-conveyor-fn/fn       core.clj: 1916
                                   ...
```